### PR TITLE
Fix no view found for id when using API 24.

### DIFF
--- a/fondazione/src/main/java/com/github/terrakok/fondazione/AppActivity.kt
+++ b/fondazione/src/main/java/com/github/terrakok/fondazione/AppActivity.kt
@@ -3,12 +3,12 @@ package com.github.terrakok.fondazione
 import android.os.Bundle
 import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import com.github.terrakok.cicerone.Cicerone
 import com.github.terrakok.cicerone.Navigator
 import com.github.terrakok.cicerone.Router
 import com.github.terrakok.cicerone.Screen
 import com.github.terrakok.cicerone.androidx.AppNavigator
-import kotlin.random.Random
 
 open class AppActivity : AppCompatActivity() {
     private lateinit var ciceroneKey: String
@@ -24,7 +24,7 @@ open class AppActivity : AppCompatActivity() {
     private val navigator by lazy { createNavigator() }
     protected open fun createNavigator(): Navigator = AppNavigator(this, navigationContainerId)
 
-    protected open val navigationContainerId: Int = Random.nextInt()
+    protected open val navigationContainerId: Int = ViewCompat.generateViewId()
     protected open val rootScreen: Screen? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/fondazione/src/main/java/com/github/terrakok/fondazione/NavigationFragment.kt
+++ b/fondazione/src/main/java/com/github/terrakok/fondazione/NavigationFragment.kt
@@ -5,12 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
 import com.github.terrakok.cicerone.Cicerone
 import com.github.terrakok.cicerone.Navigator
 import com.github.terrakok.cicerone.Router
 import com.github.terrakok.cicerone.Screen
 import com.github.terrakok.cicerone.androidx.AppNavigator
-import kotlin.random.Random
 
 open class NavigationFragment : AppFragment() {
     private lateinit var ciceroneKey: String
@@ -31,7 +31,7 @@ open class NavigationFragment : AppFragment() {
             }
         }
 
-    protected open val navigationContainerId: Int = Random.nextInt()
+    protected open val navigationContainerId: Int = ViewCompat.generateViewId()
     protected open val rootScreen: Screen? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
On API 24 devices `FragmentStateManager` crashes with exception:
```
Fatal Exception: java.lang.IllegalArgumentException
No view found for id 0xb8610aaa (unknown) for fragment SomeFragment
```

Steps to reproduce:
1. Run the app
2. Try to close it and open fast and frequently

Solution:
Use `ViewCompat.generateViewId()` which is designed to generate view
id.

My comment:
Weird thing that this crash is not occurring on latest Android
versions (e.g. API 30), probably API 24 has some specific view id
requirements.